### PR TITLE
Ignore .cxx files

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -5,6 +5,7 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+.cxx/
 
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/to/reference-keystore


### PR DESCRIPTION
This is ignored by default in new Flutter projects. Ignoring it here as well.